### PR TITLE
Change boost download to pull directly from github

### DIFF
--- a/src/boost.cmake
+++ b/src/boost.cmake
@@ -41,13 +41,7 @@ if(VERA_USE_SYSTEM_BOOST)
 else()
   include(ExternalProject)
 
-  set(BOOST_MIRROR dl.bintray.com CACHE STRING
-    "Host used to download boost. Use it to force a specific mirror.")
-  mark_as_advanced(BOOST_MIRROR)
-
   set(Boost_VERSION 1.69.0)
-  set(Boost_URL "https://${BOOST_MIRROR}/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2")
-  set(Boost_URL_HASH "SHA256=8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406")
 
   string(REPLACE "python27" "python" boostLibs "${boostLibs}")
   string(REPLACE ";" "," boostLibsComma "${boostLibs}")
@@ -103,8 +97,9 @@ else()
   endforeach()
 
   ExternalProject_Add(boost
-    URL ${Boost_URL}
-    URL_HASH ${Boost_URL_HASH}
+    GIT_REPOSITORY https://github.com/boostorg/boost.git
+    GIT_TAG boost-${Boost_VERSION}
+    GIT_PROGRESS TRUE
     CONFIGURE_COMMAND ./${bootstrap} --with-libraries=${boostLibsComma} --with-toolset=${TOOLSET}
     BUILD_COMMAND ${CMAKE_COMMAND} -E copy_if_different
       ${CMAKE_CURRENT_BINARY_DIR}/project-config.jam


### PR DESCRIPTION
Potential fix for [Issue 109](https://bitbucket.org/verateam/vera/issues/109/boost-libraries). Rather than download from a repo it now pulls directly from github.

I realise this change needs to be done in bitbucket but I'd already forked and made the change in github. This PR can be deleted if the change is added to bitbucket.