### PR TITLE
added missing angular brackets for CDATA tag

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -29,3 +29,61 @@ Origins
 Vera++ was initially hosted at:
 http://www.inspirel.com/vera
 
+
+-------------------------------------------------------------------------------
+Information regarding this forked repository
+-------------------------------------------------------------------------------
+
+New Rules
+---------
+New Rules were added to this repository, which allow more code checks. Its
+documentation can be found below.
+
+F003
+----
+Each header file shall contain an include guard consisting of the filename in
+uppercase letters and the postfix "_H_INCLUDED".
+
+T003A
+-----
+Some keywords should be followed by a single space
+(Same rule as the original rule T003, but with reduced list of keywords)
+This rule will be applied to following keywords:
+* case
+* explicit
+* extern
+* goto
+* new
+* using
+
+T003B
+-----
+Some keywords should be followed by a new line
+(Derived from the original T003, but with reduced list of keywords and
+different character to compare to)
+This rule will be applied to following keywords:
+* class
+* enum
+* struct
+* union
+
+T020
+----
+The keywords enum struct and union shall only be used with a preceeding typedef
+keyword.
+
+Packing new rules to an exisiting installation
+----------------------------------------------
+An existing vera++ installation can be extended by new rules, by simply copying
+the new rules to the 'rules' folder of the vera++ installation.
+On Debian systems this is the /usr/lib/vera++/scripts/rules folder.
+
+Packing new rules to a docker image containing vera++
+-----------------------------------------------------
+The following lines, added to a Dockerfile, adds a new rule to the vera++
+installation in a Docker image. Be careful that, when compiling the Docker
+image, the script must exist in the same folder as the Dockerfile.
+FROM debian:bookworm
+RUN apt-get -y update
+RUN apt-get -y install vera++
+ADD F003.tcl /usr/lib/vera++/scripts/rules/F003.tcl

--- a/rules/F003.tcl
+++ b/rules/F003.tcl
@@ -1,0 +1,33 @@
+#!/usr/bin/tclsh
+# Each header file shall contain an include guard consisting of the filename in uppercase letters and the postfix "_H_INCLUDED"
+
+set state "search_guard"
+foreach f [getSourceFileNames] {
+    if {[string match *.h $f]} {
+	foreach t [getTokens $f 1 0 -1 -1 {}] {
+            set tokenValue [lindex $t 0]
+	    set tokenName [lindex $t 3]
+	    if {$state == "search_guard"} {
+		if {$tokenName != "space" && $tokenName != "newline" && $tokenName != "ccomment" && $tokenName != "cppcomment" && $tokenName != "pp_ifndef" && $tokenName != "identifier"} {
+		    report $f 1 "Header file does not contain include guard"
+		}
+		if {$tokenName == "identifier"} {
+		    set lastSlash [string last "/" $f]
+		    if {$lastSlash != -1} {
+                        set fileNameWOPath [string range $f [expr {$lastSlash + 1}] end]
+		    } else {
+			set fileNameWOPath $f
+		    }
+		    set expected_guard ""
+		    append expected_guard [string map {. _} [string toupper $fileNameWOPath]] "_INCLUDED"
+		    if {$tokenValue != $expected_guard} {
+                        report $f 1 "Header file appears to have an include guard that does not match the codingguidelines. Expected \"$expected_guard\", got \"$tokenValue\""
+		    }
+		    set state "finished"
+		}
+	    }
+	}
+    } else {
+        # ignore all other non-header files
+    }
+}

--- a/rules/T003A.tcl
+++ b/rules/T003A.tcl
@@ -1,0 +1,43 @@
+#!/usr/bin/tclsh
+# Some keywords should be followed by a single space
+
+set keywords {
+    case
+    explicit
+    extern
+    goto
+    new
+    using
+}
+
+proc isKeyword {s} {
+    global keywords
+    return [expr [lsearch $keywords $s] != -1]
+}
+
+set state "other"
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {}] {
+        set tokenValue [lindex $t 0]
+        set tokenName [lindex $t 3]
+        if {$state == "keyword"} {
+            if {$tokenName == "space" && $tokenValue == " "} {
+                set state "space"
+            } else {
+                report $f $lineNumber "keyword \'${keywordValue}\' not followed by a single space"
+                set state "other"
+            }
+        } elseif {$state == "space"} {
+            if {$tokenName == "newline"} {
+                report $f $lineNumber "keyword \'${keywordValue}\' not followed by a single space"
+            }
+            set state "other"
+        } else {
+            if [isKeyword $tokenName] {
+                set state "keyword"
+                set lineNumber [lindex $t 1]
+                set keywordValue [lindex $t 0]
+            }
+        }
+    }
+}

--- a/rules/T003B.tcl
+++ b/rules/T003B.tcl
@@ -1,0 +1,36 @@
+#!/usr/bin/tclsh
+# Some keywords should be followed by a newline
+
+set keywords {
+    class
+    enum
+    struct
+    union
+}
+
+proc isKeyword {s} {
+    global keywords
+    return [expr [lsearch $keywords $s] != -1]
+}
+
+set state "other"
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {}] {
+        set tokenValue [lindex $t 0]
+        set tokenName [lindex $t 3]
+        if {$state == "keyword"} {
+            if {$tokenName == "newline"} {
+                set state "other"
+            } else {
+                report $f $lineNumber "keyword \'${keywordValue}\' not followed by a new line"
+                set state "other"
+            }
+        } else {
+            if [isKeyword $tokenName] {
+                set state "keyword"
+                set lineNumber [lindex $t 1]
+                set keywordValue [lindex $t 0]
+            }
+        }
+    }
+}

--- a/rules/T020.tcl
+++ b/rules/T020.tcl
@@ -1,0 +1,37 @@
+#!/usr/bin/tclsh
+# The keywords enum struct and union shall only be used with a preceeding typedef keyword.
+
+set keywords {
+    enum
+    struct
+    union
+}
+
+proc isKeyword {s} {
+    global keywords
+    return [expr [lsearch $keywords $s] != -1]
+}
+
+set state "other"
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {}] {
+        set tokenValue [lindex $t 0]
+        set tokenName [lindex $t 3]
+        if {$state == "typedef"} {
+            if {$tokenName == "space"} {
+                set state "typedef"
+            } else {
+                set state "other"
+            }
+        } else {
+            if {$tokenName == "typedef"} {
+		set state "typedef"
+            } elseif [isKeyword $tokenName] {
+		set state "other"
+		set lineNumber [lindex $t 1]
+		set keywordValue [lindex $t 0]
+		report $f $lineNumber "keyword \'${keywordValue}\' not preceeded by the typedef keyword"
+            }
+        }
+    }
+}

--- a/src/plugins/Reports.cpp
+++ b/src/plugins/Reports.cpp
@@ -293,12 +293,12 @@ void Reports::writeXml(std::ostream & os, bool omitDuplicates)
                 {
                     os << "        <report rule=\"" << xmlEscape(rule)
                         << "\" line=\"" << lineNumber
-                        << "\">![CDATA[" << msg << "]]</report>\n";
+                        << "\"><![CDATA[" << msg << "]]></report>\n";
                 }
                 else
                 {
                     os << "        <report line=\"" << lineNumber
-                        << "\">![CDATA[" << msg << "]]</report>\n";
+                        << "\"><![CDATA[" << msg << "]]></report>\n";
                 }
 
                 lastLineNumber = lineNumber;


### PR DESCRIPTION
When creating a xml-report vera++ tries to escape the report message with a `<![CDATA[ ... ]]>` tag.

However, in the source code the surrounding angular brackets are missing, which let the output appear as `![CDATA[ ... ]]` in the xml report. This commit would fix this issue.